### PR TITLE
Switch to gevent worker type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.8
 LABEL description="Python 3.8 based image to run emhub application"
 LABEL maintainer="J.M. de la Rosa Trevin delarosatrevin@gmail.com"
 
-RUN pip install emhub
+RUN pip install emhub gevent
 
 ENV EMHUB_INSTANCE /instance
 
-CMD [ "gunicorn", "--workers=2", "emhub:create_app()", "--bind", "0.0.0.0:8080" ]
+CMD [ "gunicorn", "-k", "gevent", "--workers=2", "emhub:create_app()", "--bind", "0.0.0.0:8080" ]


### PR DESCRIPTION
The default worker type (sync) is not suitable for polling.