### PR TITLE
Add gevent to be able to use it with gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install emhub
 
 ENV EMHUB_INSTANCE /instance
 
-CMD [ "gunicorn", "--workers=2", "emhub:create_app()", "--bind", "0.0.0.0:8080" ]
+CMD [ "gunicorn", "-k", "gevent", "--workers=2", "emhub:create_app()", "--bind", "0.0.0.0:8080" ]

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Launching the development server
     flask run
 
     # or with gunicorn:
-    gunicorn --workers=2 'emhub:create_app()' --bind 0.0.0.0:8080
+    gunicorn -k gevent --workers=2 'emhub:create_app()' --bind 0.0.0.0:8080
 
 
 To initialize the db:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask-Mail==0.9.1
 Flask-Markdown==0.3
 greenlet==1.1.0
 gunicorn==20.1.0
+gevent==21.8.0
 h5py==3.2.1
 idna==2.10
 itsdangerous==1.1.0


### PR DESCRIPTION
The default gunicorn worker type (sync) is not suitable for polling.